### PR TITLE
Wrap cart in a OrderManagerProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Cart` component is now wrapped by a `OrderManagerProvider` temporarily.
+
 ## [0.2.0] - 2019-08-19
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     "vtex.styleguide": "9.x",
     "vtex.checkout-summary": "0.x",
     "vtex.product-list": "0.x",
-    "vtex.checkout-graphql": "0.x"
+    "vtex.checkout-graphql": "0.x",
+    "vtex.order-manager": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "checkout-cart",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "title": "Checkout Cart",
   "description": "Checkout Cart",
   "defaultLocale": "pt-BR",

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -5,6 +5,7 @@ import { compose, graphql } from 'react-apollo'
 import { branch, renderComponent } from 'recompose'
 import { Spinner } from 'vtex.styleguide'
 import { ExtensionPoint } from 'vtex.render-runtime'
+import { OrderManagerProvider } from 'vtex.order-manager/OrderManager'
 
 import CartQuery from './graphql/cart.graphql'
 import UpdateItems from './graphql/updateItems.graphql'
@@ -82,8 +83,14 @@ const Cart: FunctionComponent<any> = ({ CartQuery, UpdateItems }) => {
   )
 }
 
-export default compose(
+const EnhancedCart = compose(
   graphql(CartQuery, { name: 'CartQuery', options: { ssr: false } }),
   graphql(UpdateItems, { name: 'UpdateItems' }),
   branch(({ CartQuery }: any) => !!CartQuery.loading, renderComponent(Spinner))
 )(Cart)
+
+export default () => (
+  <OrderManagerProvider>
+    <EnhancedCart />
+  </OrderManagerProvider>
+)


### PR DESCRIPTION
#### What problem is this solving?

The cart components (`product-list`, `checkout-summary`, `shipping-calculator`) will soon start using orchestrators (`order-items`, `order-summary`, `order-shipping`) to fetch and manipulate data. All those orchestrators depend on a provider of a `OrderManager` context to manage the task queue and prevent concurrency issues.

This PR wraps the `Cart` component in a `OrderManagerProvider`. This is a temporary change to facilitate the test of cart components. Our initial idea is to place this provider in a higher level component, probably `vtex.store`.

#### How should this be manually tested?

Open [this workspace](http://cartordermanager--vtexgame1.myvtex.com), add some items to the cart then go to `/cart`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/18358/incluir-order-manager-no-cart).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
