### PR TITLE
Make product-list consume from OrderItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Item list is not kept in the component's state anymore.
+
 ## [0.6.0] - 2019-08-26
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "vtex.product-list": "0.x",
     "vtex.shipping-calculator": "0.x",
     "vtex.checkout-graphql": "0.x",
-    "vtex.order-manager": "0.x"
+    "vtex.order-manager": "0.x",
+    "vtex.order-items": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -1,10 +1,8 @@
 import React, { FunctionComponent } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { OrderItemsProvider, useOrderItems } from 'vtex.order-items/OrderItems'
-import {
-  OrderManagerProvider,
-  useOrderManager,
-} from 'vtex.order-manager/OrderManager'
+import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
+import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { Button, Spinner } from 'vtex.styleguide'
 
@@ -39,7 +37,7 @@ const ProductList: FunctionComponent<ProductListProps> = ({ items }) => {
 }
 
 const Cart: FunctionComponent = () => {
-  const { loading, orderForm } = useOrderManager()
+  const { loading, orderForm } = useOrderForm()
 
   if (loading) {
     return <Spinner />
@@ -86,9 +84,11 @@ const Cart: FunctionComponent = () => {
 }
 
 const EnhancedCart = () => (
-  <OrderManagerProvider>
-    <Cart />
-  </OrderManagerProvider>
+  <OrderQueueProvider>
+    <OrderFormProvider>
+      <Cart />
+    </OrderFormProvider>
+  </OrderQueueProvider>
 )
 
 export default EnhancedCart

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -1,40 +1,16 @@
-import { debounce } from 'debounce'
-import { adjust } from 'ramda'
-import React, { FunctionComponent, useState } from 'react'
-import { compose, graphql } from 'react-apollo'
+import React, { FunctionComponent } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
-import { branch, renderComponent } from 'recompose'
-import { Button, Spinner } from 'vtex.styleguide'
+import { OrderItemsProvider, useOrderItems } from 'vtex.order-items/OrderItems'
+import {
+  OrderManagerProvider,
+  useOrderManager,
+} from 'vtex.order-manager/OrderManager'
 import { ExtensionPoint } from 'vtex.render-runtime'
-import { OrderManagerProvider } from 'vtex.order-manager/OrderManager'
+import { Button, Spinner } from 'vtex.styleguide'
 
 import CartTitle from './components/CartTitle'
-import CartQuery from './graphql/cart.graphql'
-import UpdateItems from './graphql/updateItems.graphql'
 
 import styles from './styles.css'
-
-const DEBOUNCE_TIME_MS = 300
-
-const debouncedUpdateItems = debounce(
-  (UpdateItems: any, index: number, value: number) =>
-    UpdateItems({
-      variables: {
-        orderItems: [
-          {
-            index,
-            quantity: value,
-          },
-        ],
-      },
-      refetchQueries: [
-        {
-          query: CartQuery,
-        },
-      ],
-    }),
-  DEBOUNCE_TIME_MS
-)
 
 defineMessages({
   continueShopping: {
@@ -43,44 +19,42 @@ defineMessages({
   },
 })
 
-const Cart: FunctionComponent<any> = compose(
-  graphql(CartQuery, { name: 'CartQuery', options: { ssr: false } }),
-  graphql(UpdateItems, { name: 'UpdateItems' }),
-  branch(({ CartQuery }: any) => !!CartQuery.loading, renderComponent(Spinner))
-)(({ CartQuery, UpdateItems }: any) => {
-  const {
-    cart: {
-      items,
-      storePreferencesData: { currencyCode },
-      totalizers,
-      value,
-    },
-  } = CartQuery
+interface ProductListProps {
+  items: Item[]
+}
 
-  const [curItems, setItems] = useState(items)
+const ProductList: FunctionComponent<ProductListProps> = ({ items }) => {
+  const { updateItem } = useOrderItems()
 
-  const handleQuantityChange = (index: number, value: number) => {
-    setItems(adjust(index, item => ({ ...item, quantity: value }), curItems))
-    debouncedUpdateItems(UpdateItems, index, value)
+  const handleRemove = (index: number) => updateItem(index, 0)
+
+  return (
+    <ExtensionPoint
+      id="product-list"
+      items={items}
+      onQuantityChange={updateItem}
+      onRemove={handleRemove}
+    />
+  )
+}
+
+const Cart: FunctionComponent = () => {
+  const { loading, orderForm } = useOrderManager()
+
+  if (loading) {
+    return <Spinner />
   }
 
-  const handleRemove = (index: number) => {
-    setItems([...curItems.slice(0, index), ...curItems.slice(index + 1)])
-    debouncedUpdateItems(UpdateItems, index, 0)
-  }
+  const { items, totalizers, value } = orderForm
 
   return (
     <div className={`${styles.container} bb-m b--muted-4`}>
       <div className="flex-l cf">
         <div className={`${styles.list} flex-auto-l mb6-l mt7-l mr7-l mb6-l`}>
-          <CartTitle items={curItems} />
-          <ExtensionPoint
-            id="product-list"
-            items={curItems}
-            onQuantityChange={handleQuantityChange}
-            onRemove={handleRemove}
-            currency={currencyCode}
-          />
+          <CartTitle items={items} />
+          <OrderItemsProvider>
+            <ProductList items={items} />
+          </OrderItemsProvider>
           <div className={`${styles.continue1} dn mt7 db-l fr`}>
             <Button href="/" variation="secondary" block>
               <FormattedMessage id="store/cart.continueShopping" />
@@ -98,7 +72,6 @@ const Cart: FunctionComponent<any> = compose(
               id="checkout-summary"
               totalizers={totalizers}
               total={value}
-              currency={currencyCode}
             />
           </div>
         </div>
@@ -110,7 +83,7 @@ const Cart: FunctionComponent<any> = compose(
       </div>
     </div>
   )
-})
+}
 
 const EnhancedCart = () => (
   <OrderManagerProvider>


### PR DESCRIPTION
#### What problem is this solving?

Previously we were keeping the item list in the Cart's state along with all the logic to manipulate it. This prevented us from propagating changes to the order form to other components.

[We have moved all order form data to `OrderManager`](https://github.com/vtex-apps/order-manager/pull/7) and [item manipulation logic to `OrderItems`](https://github.com/vtex-apps/order-items/pull/2). Now we don't need to keep any state in Cart anymore and `ProductList` can simply consume from `OrderItems`.

#### How should this be manually tested?

[Workspace](https://orderform--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/18319/implementar-consumer-do-order-items-no-product-list)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

We're considering moving order form data to a context separate from `OrderManager`'s queue context, but that should result only in a simple change to this PR.
