### PR TITLE
Use uniqueId to handle product list change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Product list change events are handled with the item's `uniqueId` instead of its `index`.
+
 ## [0.7.0] - 2019-08-29
 
 ### Changed

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -24,13 +24,16 @@ interface ProductListProps {
 const ProductList: FunctionComponent<ProductListProps> = ({ items }) => {
   const { updateItem } = useOrderItems()
 
-  const handleRemove = (index: number) => updateItem(index, 0)
+  const handleQuantityChange = (uniqueId: string, quantity: number) =>
+    updateItem({ uniqueId, quantity })
+  const handleRemove = (uniqueId: string) =>
+    updateItem({ uniqueId, quantity: 0 })
 
   return (
     <ExtensionPoint
       id="product-list"
       items={items}
-      onQuantityChange={updateItem}
+      onQuantityChange={handleQuantityChange}
       onRemove={handleRemove}
     />
   )


### PR DESCRIPTION
**Note:** _This PR depends on https://github.com/vtex-apps/order-items/pull/5._

#### What problem is this solving?

This makes `checkout-cart` use an item's `uniqueId` to handle change events from `product-list`, which is a safer alternative to the item's `index`, which is not immutable.

#### How should this be manually tested?

[Workspace with order-items, checkout-cart and product-list linked.](https://orderitems--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19188/possibilitar-alterar-itens-por-id).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
