### PR TITLE
Fix title alignment and add condition to display quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Title alignment on large screens.
+
+### Changed
+
+- Title does not display number of items in the cart if one of them is unavailable.
+
 ## [0.8.0] - 2019-09-05
 
 ### Changed

--- a/react/components/CartTitle.tsx
+++ b/react/components/CartTitle.tsx
@@ -1,24 +1,30 @@
 import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
+const AVAILABLE = 'available'
+
 interface Props {
   items: Item[]
 }
 
 const CartTitle: FunctionComponent<Props> = ({ items }) => {
+  const showQuantity = items.every(item => item.availability === AVAILABLE)
+
   return (
     <div>
-      <h3 className="mh5 mh6-m">
+      <h3 className="mh5 mh6-m mh0-l">
         <span className="t-heading-3 c-on-base t-heading-2-l">
           <FormattedMessage id="store/cart.title" />
         </span>
-        <span className="t-heading-5 c-muted-1 t-heading-4-l">
-          &nbsp;
-          <FormattedMessage
-            id="store/cart.items"
-            values={{ itemsQuantity: items.length }}
-          />
-        </span>
+        {showQuantity && (
+          <span className="t-heading-5 c-muted-1 t-heading-4-l">
+            &nbsp;
+            <FormattedMessage
+              id="store/cart.items"
+              values={{ itemsQuantity: items.length }}
+            />
+          </span>
+        )}
       </h3>
     </div>
   )

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,5 +1,6 @@
 interface Item {
   additionalInfo: ItemAdditionalInfo
+  availability: string
   detailUrl: string
   id: string
   imageUrl: string
@@ -12,6 +13,7 @@ interface Item {
   sellingPrice: number
   skuName: string
   skuSpecifications: SKUSpecification[]
+  uniqueId: string
 }
 
 interface ItemAdditionalInfo {


### PR DESCRIPTION
#### What problem is this solving?

This PR: 
- Fixes alignment on large screens;
- Removes the "(x items)" text from the Cart title when the product list contains an unavailable item.

#### How should this be manually tested?

[Workspace](https://carttitle--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/64570093-d615ef80-d335-11e9-8fd0-eddc555dddcf.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
