### PR TITLE
Use order-items new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Adapted product list to the changes in the `order-items` API.
+
 ## [0.8.1] - 2019-09-10
 
 ### Fixed

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -22,12 +22,11 @@ interface ProductListProps {
 }
 
 const ProductList: FunctionComponent<ProductListProps> = ({ items }) => {
-  const { updateItem } = useOrderItems()
+  const { updateQuantity, removeItem } = useOrderItems()
 
   const handleQuantityChange = (uniqueId: string, quantity: number) =>
-    updateItem({ uniqueId, quantity })
-  const handleRemove = (uniqueId: string) =>
-    updateItem({ uniqueId, quantity: 0 })
+    updateQuantity({ uniqueId, quantity })
+  const handleRemove = (uniqueId: string) => removeItem({ uniqueId })
 
   return (
     <ExtensionPoint


### PR DESCRIPTION
#### What problem is this solving?

[We're changing the `order-items` API](https://github.com/vtex-apps/order-items/pull/6) so the intent of each function becomes more clear. This PR adapts `checkout-cart` to these changes.

#### How should this be manually tested?

[Workspace](https://debounce--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19051/implementar-debouncer).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
