### PR TITLE
Shipping-calculator is now wrapped by OrderShippingProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed
+
+- `Shipping-calculator` is now wrapped by `OrderShippingProvider`.
+
 ## [0.8.2] - 2019-09-13
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
     "vtex.shipping-calculator": "0.x",
     "vtex.checkout-graphql": "0.x",
     "vtex.order-manager": "0.x",
-    "vtex.order-items": "0.x"
+    "vtex.order-items": "0.x",
+    "vtex.order-shipping": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Cart.tsx
+++ b/react/Cart.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { OrderItemsProvider, useOrderItems } from 'vtex.order-items/OrderItems'
+import { OrderShippingProvider } from 'vtex.order-shipping/OrderShipping'
 import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
 import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
 import { ExtensionPoint } from 'vtex.render-runtime'
@@ -65,7 +66,9 @@ const Cart: FunctionComponent = () => {
           className={`${styles.summary} mh5 mh0-ns bl-l b--muted-4 mh0-m pl6-l flex-fixed-l w-25-l`}
         >
           <div className="pb4 fl-m w-50-m pb6-m ph6-m pb4-l w-auto-l fn-l bn-l ph0-l">
-            <ExtensionPoint id="shipping-calculator" />
+            <OrderShippingProvider>
+              <ExtensionPoint id="shipping-calculator" />
+            </OrderShippingProvider>
           </div>
           <div className="pb4 fr-m w-50-m bl-m pb6-m ph6-m pb4-l b--muted-4 w-auto-l fn-l bn-l ph0-l">
             <ExtensionPoint


### PR DESCRIPTION
#### What problem is this solving?

In order to use OrderShipping context, shipping-calculator must be wrapped by OrderShippingProvider. 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://ordershipping--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/18320/implementar-consumer-do-order-shipping-no-shipping-calculator)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->