### PR TITLE
Add block prop to Continue Shopping button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- "Continue Shopping" button text positioning on mobile.
+
 ## [0.13.1] - 2019-10-04
 
 ### Changed

--- a/react/ContinueShopping.tsx
+++ b/react/ContinueShopping.tsx
@@ -10,7 +10,7 @@ defineMessages({
 })
 
 const ContinueShopping: FunctionComponent = () => (
-  <Button href="/" variation="secondary">
+  <Button href="/" variation="secondary" block>
     <FormattedMessage id="store/cart.continueShopping" />
   </Button>
 )


### PR DESCRIPTION
#### What problem is this solving?

This fixes the text alignment of the "Continue Shopping" button on mobile.

#### How should this be manually tested?

Add [any product](https://marcos--vtexgame1.myvtex.com/camisa-vasco-preta/p) then go to `/cart`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/24058/botão-escolher-mais-produtos-quebrado-no-mobile).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/8902498/66861125-cdcc5800-ef64-11e9-983f-24c3dbf1fbf7.png)


After:
![image](https://user-images.githubusercontent.com/8902498/66860784-35ce6e80-ef64-11e9-96cc-d8b0dd4ae4e8.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
