### PR TITLE
Implement sticky footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- "Go to checkout" button is now a sticky footer on small screens.
+
 ## [0.13.2] - 2019-10-15
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,8 @@
     "vtex.order-items": "0.x",
     "vtex.order-shipping": "0.x",
     "vtex.flex-layout": "0.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.sticky-layout": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,5 +4,6 @@
   "store/cart.items": "({itemsQuantity, plural, one {# item} other {# items}})",
   "store/cart.emptyState.title": "Your cart is empty",
   "store/cart.emptyState.message": "Add products by navigating through categories or by searching for them.",
-  "store/cart.emptyState.button": "Choose products"
+  "store/cart.emptyState.button": "Choose products",
+  "store/cart.checkout": "Checkout"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,5 +4,6 @@
   "store/cart.items": "({itemsQuantity, plural, one {# ítem} other {# ítems}})",
   "store/cart.emptyState.title": "Su carrito esta vacio",
   "store/cart.emptyState.message": "Agregue productos explorando categorías o buscándolos.",
-  "store/cart.emptyState.button": "Elige productos"
+  "store/cart.emptyState.button": "Elige productos",
+  "store/cart.checkout": "Ir a Pagar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4,5 +4,6 @@
   "store/cart.items": "({itemsQuantity, plural, one {# item} other {# itens}})",
   "store/cart.emptyState.title": "Seu carrinho está vazio",
   "store/cart.emptyState.message": "Adicione produtos navegando pelas categorias ou procurando por eles.",
-  "store/cart.emptyState.button": "Escolher produtos"
+  "store/cart.emptyState.button": "Escolher produtos",
+  "store/cart.checkout": "Continuar"
 }

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -1,0 +1,21 @@
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Button } from 'vtex.styleguide'
+
+const GoToCheckoutButton: FunctionComponent = () => {
+  return (
+    <div className="pv3 bg-white">
+      <Button
+        id="proceed-to-checkout"
+        href="/checkout/#payment"
+        variation="primary"
+        size="large"
+        block
+      >
+        <FormattedMessage id="store/cart.checkout" />
+      </Button>
+    </div>
+  )
+}
+
+export default GoToCheckoutButton

--- a/store/blocks/common.json
+++ b/store/blocks/common.json
@@ -35,5 +35,8 @@
     "props": {
       "orientation": "horizontal"
     }
+  },
+  "flex-layout.row#go-to-checkout": {
+    "children": ["go-to-checkout"]
   }
 }

--- a/store/blocks/single-col.json
+++ b/store/blocks/single-col.json
@@ -18,16 +18,23 @@
       "flex-layout.row#product-list",
       "flex-layout.row#shipping",
       "flex-layout.row#summary",
+      "sticky-layout#go-to-checkout",
       "flex-layout.row#continue-shopping.block"
     ],
     "props": {
       "marginBottom": 6
     }
   },
+  "sticky-layout#go-to-checkout": {
+    "children": ["flex-layout.row#go-to-checkout"],
+    "props": {
+      "position": "bottom"
+    }
+  },
   "flex-layout.row#continue-shopping.block": {
     "children": ["continue-shopping"],
     "props": {
-      "marginTop": 7
+      "marginTop": 6
     }
   }
 }

--- a/store/blocks/two-cols.json
+++ b/store/blocks/two-cols.json
@@ -61,7 +61,8 @@
   "flex-layout.col#right-content": {
     "children": [
       "flex-layout.row#shipping",
-      "flex-layout.row#summary"
+      "flex-layout.row#summary",
+      "flex-layout.row#go-to-checkout"
     ],
     "props": {
       "blockClass": "sidebarContent",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -48,5 +48,8 @@
   },
   "divider": {
     "component": "DividerWrapper"
+  },
+  "go-to-checkout": {
+    "component": "GoToCheckout"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR implements a sticky footer with the go-to-checkout button on mobile screens using the `sticky-layout` component.

In order to make this change I had to move the button from `checkout-summary` to `checkout-cart`, which I believe is a more appropriate location anyway. I'll follow up with a PR that removes the button from `checkout-summary`.

#### How should this be manually tested?

Go to [this workspace](https://sticky--vtexgame1.myvtex.com), add about 3 items then go to `/cart`. Set the screen size to phone and verify the footer behaves _fundamentally*_ as expected.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/24232/implementar-footer-fixo-no-s-do-carrinho).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![sticky](https://user-images.githubusercontent.com/8902498/67045752-4a963800-f105-11e9-801e-a461cc8151ad.gif)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
- *The `sticky-layout` flicks a little bit on mobile devices. I talked to @lbebber and he is aware of the issue.
- This might need some style adjustments, which I'll leave to a future PR.

<!-- Put any relevant information that doesn't fit in the other sections here. -->
