### PR TITLE
Add the needed coupon info as props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `checkout-coupon` info as props.
+
 ## [0.18.1] - 2019-11-07
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "vtex.order-manager": "0.x",
     "vtex.order-items": "0.x",
     "vtex.order-shipping": "0.x",
+    "vtex.order-coupon": "0.x",
     "vtex.flex-layout": "0.x",
     "vtex.device-detector": "0.x",
     "vtex.sticky-layout": "0.x",

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -1,19 +1,40 @@
 import React, { FunctionComponent } from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
+import {
+  OrderCouponProvider,
+  useOrderCoupon,
+} from 'vtex.order-coupon/OrderCoupon'
 
 const SummaryWrapper: FunctionComponent = () => {
   const {
+    loading,
     orderForm: { totalizers, value },
   } = useOrderForm()
+
+  const {
+    coupon,
+    insertCoupon,
+    couponErrorKey,
+  } = useOrderCoupon()
 
   return (
     <ExtensionPoint
       id="checkout-summary"
+      loading={loading}
       totalizers={totalizers}
       total={value}
+      coupon={coupon}
+      insertCoupon={insertCoupon}
+      couponErrorKey={couponErrorKey}
     />
   )
 }
 
-export default SummaryWrapper
+const EnhancedSummary = () => (
+  <OrderCouponProvider>
+    <SummaryWrapper />
+  </OrderCouponProvider>
+)
+
+export default EnhancedSummary


### PR DESCRIPTION
#### What problem is this solving?

Since the orchestrators dependencies were removed from the UI components, `checkout-cart` now needs to provide the needed data. This PR adds the missing coupon info.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://buttonloading--checkoutio.myvtex.com/cart)
- Try to remove and/or insert a coupon
- See if it works ok.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->