### PR TITLE
Remove couponErrorKey prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `couponErrorKey` prop, since its no longer necessary.
+
 ## [0.19.0] - 2019-11-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-- `couponErrorKey` prop, since its no longer necessary.
+- `couponErrorKey` prop, since it is no longer necessary.
 
 ## [0.19.0] - 2019-11-08
 

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -12,11 +12,7 @@ const SummaryWrapper: FunctionComponent = () => {
     orderForm: { totalizers, value },
   } = useOrderForm()
 
-  const {
-    coupon,
-    insertCoupon,
-    couponErrorKey,
-  } = useOrderCoupon()
+  const { coupon, insertCoupon } = useOrderCoupon()
 
   return (
     <ExtensionPoint
@@ -26,7 +22,6 @@ const SummaryWrapper: FunctionComponent = () => {
       total={value}
       coupon={coupon}
       insertCoupon={insertCoupon}
-      couponErrorKey={couponErrorKey}
     />
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

`couponErrorKey` prop is no longer necessary. This PR removes it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixcouponerror--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify its working normally

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
