### PR TITLE
Remove OrderManager providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `OrderFormProvider` and `OrderQueueProvider`, as they are now provided by `vtex.store`.
+
 ## [0.20.0] - 2019-11-14
 
 ### Removed

--- a/react/CartWrapper.tsx
+++ b/react/CartWrapper.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useEffect } from 'react'
-import { OrderFormProvider, useOrderForm } from 'vtex.order-manager/OrderForm'
-import { OrderQueueProvider } from 'vtex.order-manager/OrderQueue'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
 
@@ -36,13 +35,9 @@ const CartWrapper: FunctionComponent = () => {
 }
 
 const EnhancedCartWrapper = () => (
-  <OrderQueueProvider>
-    <OrderFormProvider>
-      <CartToastProvider>
-        <CartWrapper />
-      </CartToastProvider>
-    </OrderFormProvider>
-  </OrderQueueProvider>
+  <CartToastProvider>
+    <CartWrapper />
+  </CartToastProvider>
 )
 
 export default EnhancedCartWrapper


### PR DESCRIPTION
#### What problem is this solving?

`vtex.store` is now providing both `OrderFormProvider` and `OrderQueueProvider`, so we can remove them from `vtex.checkout-cart`.

#### How should this be manually tested?

Simply interact with [this workspace](https://marcos3--checkoutio.myvtex.com/cart/add?sku=291&sku=256&sku=287&sku=308&sku=288&sku=306&sku=330&sku=36&sku=269&sku=321).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/26565/tirar-providers-do-order-manager-do-checkout-cart).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
