### PR TITLE
Add schemas for cart title and buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `schema` to title and buttons so they appear in Site Editor.
+
 ## [0.21.1] - 2019-11-19
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     "vtex.device-detector": "0.x",
     "vtex.sticky-layout": "0.x",
     "vtex.checkout-resources": "0.x",
-    "vtex.store-resources": "0.x"
+    "vtex.store-resources": "0.x",
+    "vtex.native-types": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,5 +6,9 @@
   "store/cart.emptyState.message": "Add products by navigating through categories or by searching for them.",
   "store/cart.emptyState.button": "Choose products",
   "store/cart.checkout": "Checkout",
-  "store/cart.removeToast": "Item {name} was removed from the cart"
+  "store/cart.removeToast": "Item {name} was removed from the cart",
+  "admin/editor.cart.label": "Cart",
+  "admin/editor.cart.title": "Title",
+  "admin/editor.cart.continueShopping": "Continue shopping button",
+  "admin/editor.cart.checkout": "Checkout button"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,5 +6,9 @@
   "store/cart.emptyState.message": "Agregue productos explorando categorías o buscándolos.",
   "store/cart.emptyState.button": "Elige productos",
   "store/cart.checkout": "Ir a Pagar",
-  "store/cart.removeToast": "El ítem {name} se ha eliminado del carrito"
+  "store/cart.removeToast": "El ítem {name} se ha eliminado del carrito",
+  "admin/editor.cart.label": "Carrito",
+  "admin/editor.cart.title": "Título",
+  "admin/editor.cart.continueShopping": "Botón seguir comprando",
+  "admin/editor.cart.checkout": "Botón ir a pagar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,5 +6,9 @@
   "store/cart.emptyState.message": "Adicione produtos navegando pelas categorias ou procurando por eles.",
   "store/cart.emptyState.button": "Escolher produtos",
   "store/cart.checkout": "Continuar",
-  "store/cart.removeToast": "O item {name} foi removido do carrinho"
+  "store/cart.removeToast": "O item {name} foi removido do carrinho",
+  "admin/editor.cart.label": "Carrinho",
+  "admin/editor.cart.title": "Título",
+  "admin/editor.cart.continueShopping": "Botão escolher mais produtos",
+  "admin/editor.cart.checkout": "Botão continuar"
 }

--- a/react/CartWrapper.tsx
+++ b/react/CartWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useEffect } from 'react'
+import { defineMessages } from 'react-intl'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
@@ -7,6 +8,13 @@ import {
   CartToastProvider,
   useCartToastContext,
 } from './components/ToastContext'
+
+const messages = defineMessages({
+  label: {
+    id: 'admin/editor.cart.label',
+    defaultMessage: '',
+  },
+})
 
 const CartWrapper: FunctionComponent = () => {
   const { loading, orderForm } = useOrderForm()
@@ -34,10 +42,14 @@ const CartWrapper: FunctionComponent = () => {
   )
 }
 
-const EnhancedCartWrapper = () => (
+const EnhancedCartWrapper: StorefrontFunctionComponent = () => (
   <CartToastProvider>
     <CartWrapper />
   </CartToastProvider>
 )
+
+EnhancedCartWrapper.schema = {
+  title: messages.label.id,
+}
 
 export default EnhancedCartWrapper

--- a/react/ContinueShopping.tsx
+++ b/react/ContinueShopping.tsx
@@ -1,18 +1,30 @@
-import React, { FunctionComponent } from 'react'
+import React from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 
-defineMessages({
+const messages = defineMessages({
   continueShopping: {
     defaultMessage: 'Continue Shopping',
     id: 'store/cart.continueShopping',
   },
+  label: {
+    defaultMessage: '',
+    id: 'admin/editor.cart.continueShopping',
+  },
 })
 
-const ContinueShopping: FunctionComponent = () => (
+const ContinueShopping: StorefrontFunctionComponent<Props> = ({ label }) => (
   <Button href="/" variation="secondary" block>
-    <FormattedMessage id="store/cart.continueShopping" />
+    <FormattedMessage id={label} />
   </Button>
 )
+
+interface Props {
+  label: string
+}
+
+ContinueShopping.schema = {
+  title: messages.label.id,
+}
 
 export default ContinueShopping

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -1,8 +1,15 @@
-import React, { FunctionComponent } from 'react'
-import { FormattedMessage } from 'react-intl'
+import React from 'react'
+import { FormattedMessage, defineMessages } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 
-const GoToCheckoutButton: FunctionComponent = () => {
+const messages = defineMessages({
+  label: {
+    id: 'admin/editor.cart.checkout',
+    defaultMessage: '',
+  },
+})
+
+const GoToCheckoutButton: StorefrontFunctionComponent<Props> = ({ label }) => {
   return (
     <div>
       <Button
@@ -12,10 +19,18 @@ const GoToCheckoutButton: FunctionComponent = () => {
         size="large"
         block
       >
-        <FormattedMessage id="store/cart.checkout" />
+        <FormattedMessage id={label} />
       </Button>
     </div>
   )
+}
+
+interface Props {
+  label: string
+}
+
+GoToCheckoutButton.schema = {
+  title: messages.label.id,
 }
 
 export default GoToCheckoutButton

--- a/react/Title.tsx
+++ b/react/Title.tsx
@@ -1,10 +1,21 @@
-import React, { FunctionComponent } from 'react'
-import { FormattedMessage } from 'react-intl'
+import React from 'react'
+import { defineMessages, FormattedMessage } from 'react-intl'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 const AVAILABLE = 'available'
 
-const CartTitle: FunctionComponent = () => {
+const messages = defineMessages({
+  label: {
+    id: 'admin/editor.cart.title',
+    defaultMessage: '',
+  },
+  title: {
+    id: 'store/cart.title',
+    defaultMessage: '',
+  },
+})
+
+const CartTitle: StorefrontFunctionComponent<Props> = ({ title }) => {
   const {
     orderForm: { items },
     loading,
@@ -18,7 +29,7 @@ const CartTitle: FunctionComponent = () => {
     <div>
       <h3 className="mt6 mt7-l">
         <span className="t-heading-3 c-on-base t-heading-2-l">
-          <FormattedMessage id="store/cart.title" />
+          <FormattedMessage id={title} />
         </span>
         &nbsp;
         {!loading && showQuantity && (
@@ -35,6 +46,14 @@ const CartTitle: FunctionComponent = () => {
       </h3>
     </div>
   )
+}
+
+interface Props {
+  title: string
+}
+
+CartTitle.schema = {
+  title: messages.label.id,
 }
 
 export default CartTitle

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,29 @@
+{
+  "definitions": {
+    "Title": {
+      "properties": {
+        "title": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/cart.title"
+        }
+      },
+      "title": "title"
+    },
+    "ContinueShopping": {
+      "properties": {
+        "label": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/cart.continueShopping"
+        }
+      }
+    },
+    "GoToCheckout": {
+      "properties": {
+        "label": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/cart.checkout"
+        }
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -29,14 +29,20 @@
     "allowed": "*"
   },
   "title": {
-    "component": "Title"
+    "component": "Title",
+    "content": {
+      "$ref": "#/definitions/Title"
+    }
   },
   "product-list-wrapper": {
     "component": "ProductList",
     "allowed": ["product-list"]
   },
   "continue-shopping": {
-    "component": "ContinueShopping"
+    "component": "ContinueShopping",
+    "content": {
+      "$ref": "#/definitions/ContinueShopping"
+    }
   },
   "shipping-wrapper": {
     "component": "Shipping",
@@ -50,7 +56,10 @@
     "component": "DividerWrapper"
   },
   "go-to-checkout": {
-    "component": "GoToCheckout"
+    "component": "GoToCheckout",
+    "content": {
+      "$ref": "#/definitions/GoToCheckout"
+    }
   },
   "checkout-cart-add": {
     "component": "AddToCartUrl"


### PR DESCRIPTION
#### What problem is this solving?

This makes the title and buttons of the new cart appear in the Site Editor so their texts can be edited.

#### How should this be manually tested?

[Add an item to cart](https://schemas--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17), then head to the [Site Editor](https://schemas--checkoutio.myvtex.com/admin/cms/site-editor/cart). Try changing the texts of the title and buttons in Portuguese, and verify those changes are reflected in the other languages.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/26707/adicionar-schema-nos-componentes-para-aparecerem-no-site-editor).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/69584921-1c85fc80-0fbd-11ea-962f-0d6629edc568.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
