### PR TITLE
Fix add to cart URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `AddToCartUrl` not working on some devices.
+
 ## [0.21.1] - 2019-11-19
 
 ### Added

--- a/react/AddToCartUrl.tsx
+++ b/react/AddToCartUrl.tsx
@@ -40,9 +40,7 @@ const AddToCartUrl: FunctionComponent = () => {
         variables: {
           items: newItems,
         },
-      })
-
-      window.location.replace('/cart')
+      }).then(() => window.location.replace('/cart'))
     }
   }, [loading])
 


### PR DESCRIPTION
#### What problem is this solving?

The `/cart/add` path was not working consistently on some devices. Investigation revealed that the `addToCart` mutation was not even reaching the backend. The fix to this issue was to wait for the mutation to resolve before redirecting the user to the Cart page. This does add a bit of latency before the user is redirected, though, so if this becomes a problem I can try some kind of in-between solution.

#### How should this be manually tested?

[Workspace](https://add--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17). Tested on my iPhone and Xcode's Simulator and it worked every time.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/26639/adicionar-item-pela-url-não-funciona).
- [ ] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
