### PR TITLE
Remove sticky-layout from "Go to checkout" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `sticky-layout` from the "Go to checkout" button.
+
 ## [0.22.1] - 2019-12-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,6 @@
     "vtex.order-coupon": "0.x",
     "vtex.flex-layout": "0.x",
     "vtex.device-detector": "0.x",
-    "vtex.sticky-layout": "0.x",
     "vtex.checkout-resources": "0.x",
     "vtex.store-resources": "0.x",
     "vtex.native-types": "0.x"

--- a/store/blocks/single-col.json
+++ b/store/blocks/single-col.json
@@ -20,17 +20,11 @@
       "flex-layout.row#product-list",
       "flex-layout.row#shipping",
       "flex-layout.row#summary",
-      "sticky-layout#go-to-checkout",
+      "flex-layout.row#go-to-checkout",
       "flex-layout.row#continue-shopping.block"
     ],
     "props": {
       "marginBottom": 6
-    }
-  },
-  "sticky-layout#go-to-checkout": {
-    "children": ["flex-layout.row#go-to-checkout"],
-    "props": {
-      "position": "bottom"
     }
   },
   "flex-layout.row#continue-shopping.block": {


### PR DESCRIPTION
#### What problem is this solving?

The `sticky-layout` component is still not working 100% fine. While we work on it we will remove it from the new Cart so we can launch it.

#### How should this be manually tested?

[Workspace](https://nosticky--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/27421/remover-o-sticky-layout-do-botão-de-seguir-para-o-checkout).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
