### PR TITLE
Add canEditData prop to shipping-calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.22.2] - 2019-12-04
-
 ### Added
 
 - `canEditData` prop to `shipping-calculator`.
+
+## [0.22.2] - 2019-12-04
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.22.2] - 2019-12-04
 
+### Added
+
+- `canEditData` prop to `shipping-calculator`.
+
 ### Removed
 
 - `sticky-layout` from the "Go to checkout" button.

--- a/react/Shipping.tsx
+++ b/react/Shipping.tsx
@@ -9,6 +9,7 @@ import {
 const ShippingWrapper: FunctionComponent = () => {
   const { loading } = useOrderForm()
   const {
+    canEditData,
     countries,
     deliveryOptions,
     insertAddress,
@@ -20,6 +21,7 @@ const ShippingWrapper: FunctionComponent = () => {
     <ExtensionPoint
       id="shipping-calculator"
       loading={loading}
+      canEditData={canEditData}
       countries={countries}
       deliveryOptions={deliveryOptions}
       insertAddress={insertAddress}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds `canEditData` info to `shipping-calculator`.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to  [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart).
- Verify that edit postal code button isn't available.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/27047/remover-a-op%C3%A7%C3%A3o-de-alterar-cep-no-carrinho-quando-usu%C3%A1rio-estiver-identificado)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
