### PR TITLE
Coupon info is now provided by OrderForm instead of OrderCoupon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The selected `coupon` info is now provided by `useOrderForm` instead of `useOrderCoupon`.
 
 ## [0.24.3] - 2019-12-30
 ### Changed

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -9,10 +9,14 @@ const { OrderCouponProvider, useOrderCoupon } = OrderCoupon
 const SummaryWrapper: FunctionComponent = () => {
   const {
     loading,
-    orderForm: { totalizers, value },
+    orderForm: {
+      totalizers,
+      value,
+      marketingData: { coupon },
+    },
   } = useOrderForm()
 
-  const { coupon, insertCoupon } = useOrderCoupon()
+  const { insertCoupon } = useOrderCoupon()
 
   return (
     <ExtensionPoint


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the responsibility of providing the selected `coupon` info from `useOrderCoupon`. With this, besides making `OrderCoupon` concentrate only manipulation functions, we ensure that `useOrderForm` is the only source of truth when it comes to `orderForm` data.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Proceed to [Workspace](https://ordercoupontests--checkoutio.myvtex.com/cart/add?sku=288)
- Try to insert the coupon `testegratis`
- Check if the coupon is inserted

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/29728/remover-informa%C3%A7%C3%A3o-de-coupon-de-ordercoupon-transformando-o-orderform-na-%C3%BAnica-fonte-de-dados)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
