### PR TITLE
Add Cartman interface and extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Interface `checkout-cartman` and Extension Point so Cartman can inject itself in the Cart page.
 
 ## [0.24.6] - 2020-04-16
 ### Changed

--- a/react/CartWrapper.tsx
+++ b/react/CartWrapper.tsx
@@ -51,6 +51,7 @@ const CartWrapper: FunctionComponent = () => {
 
 const EnhancedCartWrapper: StorefrontFunctionComponent = () => (
   <CartToastProvider>
+    <ExtensionPoint id="checkout-cartman" />
     <CartWrapper />
   </CartToastProvider>
 )

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -4,7 +4,8 @@
     "allowed": [
       "checkout-cart-single-col",
       "checkout-cart-two-cols",
-      "empty-state"
+      "empty-state",
+      "checkout-cartman"
     ]
   },
   "empty-state": {
@@ -63,5 +64,9 @@
   },
   "checkout-cart-add": {
     "component": "AddToCartUrl"
+  },
+  "checkout-cartman": {
+    "component": "*",
+    "render": "lazy"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Adds an interface so we can have [cartman](https://github.com/vtex-apps/checkout-cartman) automatically inject itself in the cart page.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/cart). Note that you need to have a call-center operator permission in order to see Cartman (you may also need to remove all cookies and clear localStorage).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/10223856/79610451-f3cae480-80ce-11ea-8cd4-22249dd93225.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->