### PR TITLE
Use navigate instead of location.assign with Checkout IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use `navigate` from `vtex.render-runtime` when on `vtex.checkout@2.x` major.
 
 ## [0.25.1] - 2020-06-22
 ### Fixed

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { FormattedMessage, defineMessages } from 'react-intl'
 import { Button } from 'vtex.styleguide'
+import { Utils } from 'vtex.checkout-resources'
+import { useRuntime } from 'vtex.render-runtime'
 
 const messages = defineMessages({
   label: {
@@ -9,14 +11,27 @@ const messages = defineMessages({
   },
 })
 
+const { useCheckoutURL } = Utils
+
 const GoToCheckoutButton: StorefrontFunctionComponent<Props> = ({ label }) => {
+  const { navigate } = useRuntime()
+  const { major } = useCheckoutURL()
+
+  const handleGoToCheckout = () => {
+    if (major >= 2) {
+      navigate({ page: 'store.checkout.order-form' })
+    } else {
+      window.location.assign('/checkout/#payment')
+    }
+  }
+
   return (
     <div>
       <Button
         id="proceed-to-checkout"
-        href="/checkout/#payment"
         variation="primary"
         size="large"
+        onClick={handleGoToCheckout}
         block
       >
         <FormattedMessage id={label} />


### PR DESCRIPTION
#### What problem is this solving?

Use render's `navigate` method for faster page transitions when using Checkout on IO.

#### How to test it?

[`checkoutio` workspace](https://cartnavigate--checkoutio.myvtex.com/cart/add?sku=289) and [`fashionmix` workspace](https://cartnavigate--gc-cli6734.myvtex.com/cart/add?sku=164788).

Basically this feature should only work on workspaces that have the `2.x` major of `vtex.checkout`. I linked in a account that doesn't have the `2.x` major to see if there is any regression.

To test you can simply press the "go to checkout" button, and on `checkoutio` you should see the render loading bar before being redirected to checkout. On `fashionmix` you should be redirected without seeing the render loading bar (same behaviour as before).

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A