### PR TITLE
CHK-328: Add addToCart and removeFromCart pixel events on product list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Pixel events `addToCart` and `removeFromCart`.
 
 ## [0.26.0] - 2020-09-09
 ### Added

--- a/react/utils/pixel.ts
+++ b/react/utils/pixel.ts
@@ -15,6 +15,7 @@ interface PixelCartItem {
   detailUrl: string
   imageUrl: string
   referenceId: string
+  seller: string
 }
 
 /**
@@ -72,5 +73,6 @@ export function mapCartItemToPixel(item: CartItem): PixelCartItem {
       ? fixUrlProtocol(item.imageUrls.at3x)
       : item.imageUrl ?? '',
     referenceId: item.refId ?? '',
+    seller: item.seller,
   }
 }

--- a/react/utils/pixel.ts
+++ b/react/utils/pixel.ts
@@ -1,0 +1,76 @@
+import { Item } from 'vtex.checkout-graphql'
+
+type CartItem = Item & { imageUrl?: string }
+
+interface PixelCartItem {
+  skuId: string
+  variant: string
+  price: number
+  name: string
+  quantity: number
+  productId: string
+  productRefId: string
+  brand: string
+  category: string
+  detailUrl: string
+  imageUrl: string
+  referenceId: string
+}
+
+/**
+ * URL comes like "//storecomponents.vteximg.com.br/arquivos/ids/155491"
+ * this function guarantees it comes with protocol in it.
+ */
+function fixUrlProtocol(url: string) {
+  if (!url || url.indexOf('http') === 0) {
+    return url
+  }
+
+  return `https:${url}`
+}
+
+/**
+ * Remove the variant from the end of the name.
+ * Ex: from "Classic Shoes Pink" to "Classic Shoes"
+ */
+function getNameWithoutVariant(item: CartItem) {
+  if (!item.name?.includes(item.skuName ?? '')) {
+    return item.name ?? ''
+  }
+
+  const leadingSpace = 1
+  const variantLength = leadingSpace + (item.skuName?.length ?? 0)
+
+  return item.name.slice(0, item.name.length - variantLength) ?? ''
+}
+
+function productCategory(item: CartItem) {
+  try {
+    const categoryIds =
+      item.productCategoryIds?.split('/').filter(c => c.length) ?? []
+    const category = categoryIds.map(id => item.productCategories[id]).join('/')
+
+    return category
+  } catch {
+    return ''
+  }
+}
+
+export function mapCartItemToPixel(item: CartItem): PixelCartItem {
+  return {
+    skuId: item.id,
+    variant: item.skuName ?? '',
+    price: item.sellingPrice ?? 0,
+    name: getNameWithoutVariant(item),
+    quantity: item.quantity,
+    productId: item.productId,
+    productRefId: item.productRefId ?? '',
+    brand: item.additionalInfo?.brandName ?? '',
+    category: productCategory(item),
+    detailUrl: item.detailUrl ?? '',
+    imageUrl: item.imageUrls
+      ? fixUrlProtocol(item.imageUrls.at3x)
+      : item.imageUrl ?? '',
+    referenceId: item.refId ?? '',
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds the events of `addToCart` when you change the product quantity and `removeFromCart` when you remove a product.

#### How to test it?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

You can test by editing or removing the item and seeing if `window.dataLayer` contains the `addToCart` and/or `removeFromCart` events properly registered.

#### Screenshots or example usage:

N/A

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A