### PR TITLE
CHK-344: Add interface to include one click buy buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Interface for one click buy buttons.
 
 ## [0.27.0] - 2020-09-14
 ### Added

--- a/react/CartWrapper.tsx
+++ b/react/CartWrapper.tsx
@@ -6,10 +6,7 @@ import { useDevice } from 'vtex.device-detector'
 import { Message } from 'vtex.checkout-graphql'
 import { PixelContext } from 'vtex.pixel-manager'
 
-import {
-  CartToastProvider,
-  useCartToastContext,
-} from './components/ToastContext'
+import { CartToastProvider, useCartToastContext } from './ToastContext'
 
 const { usePixel } = PixelContext
 const { useOrderForm } = OrderForm

--- a/react/OneClickBuyWrapper.tsx
+++ b/react/OneClickBuyWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 
 const OneClickBuyWrapper: StorefrontFunctionComponent = () => (
-    <ExtensionPoint id="one-click-buy" />
+  <ExtensionPoint id="one-click-buy" />
 )
 
 export default OneClickBuyWrapper

--- a/react/OneClickBuyWrapper.tsx
+++ b/react/OneClickBuyWrapper.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { ExtensionPoint } from 'vtex.render-runtime'
+
+const OneClickBuyWrapper: StorefrontFunctionComponent = () => (
+    <ExtensionPoint id="one-click-buy" />
+)
+
+export default OneClickBuyWrapper

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -6,7 +6,7 @@ import { ExtensionPoint } from 'vtex.render-runtime'
 import { Item } from 'vtex.checkout-graphql'
 import { PixelContext } from 'vtex.pixel-manager'
 
-import { useCartToastContext } from './components/ToastContext'
+import { useCartToastContext } from './ToastContext'
 import { mapCartItemToPixel } from './utils/pixel'
 
 const { usePixel } = PixelContext

--- a/react/ToastContext.tsx
+++ b/react/ToastContext.tsx
@@ -52,3 +52,5 @@ export const useCartToastContext = () => {
 
   return context
 }
+
+export default { useCartToastContext }

--- a/store/blocks/two-cols.json
+++ b/store/blocks/two-cols.json
@@ -66,7 +66,8 @@
     "children": [
       "flex-layout.row#shipping",
       "flex-layout.row#summary",
-      "flex-layout.row#go-to-checkout"
+      "flex-layout.row#go-to-checkout",
+      "one-click-buy-wrapper"
     ],
     "props": {
       "blockClass": "sidebarContent",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -5,7 +5,8 @@
       "checkout-cart-single-col",
       "checkout-cart-two-cols",
       "empty-state",
-      "checkout-cartman"
+      "checkout-cartman",
+      "one-click-buy"
     ]
   },
   "empty-state": {
@@ -68,5 +69,16 @@
   "checkout-cartman": {
     "component": "*",
     "render": "lazy"
+  },
+  "one-click-buy": {
+    "component": "*",
+    "render": "lazy"
+  },
+  "one-click-buy-wrapper": {
+    "component": "OneClickBuyWrapper",
+    "render": "lazy",
+    "allowed": [
+      "one-click-buy"
+    ]
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the interface so we can display "one-click buy buttons" in the cart page, such as Visa Checkout.

#### How to test it?

[Workspace](https://lucaslucas--carrefourbrfood.myvtex.com/cart/add?sku=678).

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/10223856/93090870-c1201a80-f673-11ea-9e67-c3369e5137fc.png)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A