### PR TITLE
Use navigate when redirecting to checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use navigate when redirecting to the checkout.
+
 ## [0.30.1] - 2020-10-07
 ### Changed
 - Make summary in sidebar sticky to prevent going offscreen on long carts.

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -21,7 +21,7 @@ const GoToCheckoutButton: StorefrontFunctionComponent<Props> = ({ label }) => {
     if (major >= 2) {
       navigate({ page: 'store.checkout.order-form' })
     } else {
-      window.location.assign('/checkout/#payment')
+      navigate({ page: '/checkout/#payment', fallbackToWindowLocation: true })
     }
   }
 

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -19,9 +19,15 @@ const GoToCheckoutButton: StorefrontFunctionComponent<Props> = ({ label }) => {
 
   const handleGoToCheckout = () => {
     if (major >= 2) {
-      navigate({ page: 'store.checkout.order-form' })
+      navigate({
+        page: 'store.checkout.order-form',
+        fallbackToWindowLocation: false,
+      })
     } else {
-      navigate({ page: '/checkout/#payment', fallbackToWindowLocation: true })
+      navigate({
+        to: `/checkout/#/payment`,
+        fallbackToWindowLocation: true,
+      })
     }
   }
 

--- a/react/GoToCheckout.tsx
+++ b/react/GoToCheckout.tsx
@@ -25,7 +25,7 @@ const GoToCheckoutButton: StorefrontFunctionComponent<Props> = ({ label }) => {
       })
     } else {
       navigate({
-        to: `/checkout/#/payment`,
+        to: '/checkout/#/payment',
         fallbackToWindowLocation: true,
       })
     }


### PR DESCRIPTION
#### What problem is this solving?

Use navigate when redirecting to checkout cart to permit adding the loading bar on top of the document.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

In the workspace try to add to cart and verify if everything is ok( with the redirect) and if the document has a loading bar in the process.

https://vitorflg--gc-jqu0734.myvtex.com/

#### Screenshots or example usage:

X

#### Describe alternatives you've considered, if any.

X

#### Related to / Depends on

https://github.com/vtex-apps/render-runtime/pull/567


