### PR TITLE
CHK-341: Add sticky positioning to cart summary in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make summary in sidebar sticky to prevent going offscreen on long carts.
 
 ## [0.30.0] - 2020-09-28
 ### Added

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "@types/recompose": "^0.30.6",
     "@vtex/test-tools": "^0.2.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.40.0/public/@types/vtex.checkout-graphql",
     "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.35.0/public/@types/vtex.checkout-resources",
     "vtex.checkout-splunk": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-splunk@0.1.0/public/@types/vtex.checkout-splunk",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4733,10 +4733,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.4.3"

--- a/store/blocks/common.json
+++ b/store/blocks/common.json
@@ -43,8 +43,8 @@
     "children": ["go-to-checkout"],
     "props": {
       "blockClass": "goToCheckout",
-      "paddingBottom": 4,
-      "paddingTop": 4
+      "paddingTop": 4,
+      "paddingBottom": 4
     }
   }
 }

--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -63,7 +63,14 @@
 /* Sidebar */
 
 .flexRow--sidebar {
-  margin-top: 5.84em;
+  margin-top: 5.84rem;
+  margin-bottom: 2rem;
+  top: 5.84rem;
+  position: sticky;
+}
+
+.flexRow--sidebar .flexRowContent--goToCheckout {
+  padding-bottom: 0;
 }
 
 /* M, L */
@@ -77,7 +84,8 @@
 /* L+ */
 @media screen and (min-width: 64em) {
   .flexRow--sidebar {
-    margin-top: 7em;
+    margin-top: 7rem;
+    top: 7rem;
   }
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Makes the summary visible throughout the cart length.

#### How to test it?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289&qty=2&seller=1&sku=61&qty=1&seller=1&sku=57&qty=1&seller=1&sku=56&qty=1&seller=1&sku=249&qty=1&seller=1&sku=292&qty=1&seller=1&sku=24&qty=1&seller=1&sku=332&qty=1&seller=1&sku=62&qty=1&seller=1&sku=55&qty=1&seller=1&sku=60&qty=1&seller=1&sku=31&qty=1&seller=1&sku=340&qty=1&seller=1&sku=341&qty=1&seller=1&sku=305&qty=1&seller=1&sku=70&qty=1&seller=1&sku=15&qty=1&seller=1&sku=1&qty=1&seller=1&sku=54&qty=1&seller=1&sku=331&qty=1&seller=1&sku=304&qty=1&seller=1&sku=293&qty=1&seller=1&sku=301&qty=1&seller=1&sku=68&qty=1&seller=1&sku=303&qty=1&seller=1&sku=286&qty=1&seller=1&sku=2&qty=1&seller=1&sku=311&qty=1&seller=1&sku=13&qty=1&seller=1&sku=267&qty=1&seller=1&sku=16&qty=1&seller=1&sku=250&qty=1&seller=1&sku=299&qty=1&seller=1&sku=288&qty=1&seller=1&sku=327&qty=1&seller=1&sku=261&qty=1&seller=1&sku=53&qty=1&seller=1&sku=302&qty=1&seller=1&sku=48&qty=1&seller=1&sku=310&qty=1&seller=1&sku=338&qty=1&seller=1&sku=72&qty=1&seller=1&sku=64&qty=1&seller=1&sku=247&qty=1&seller=1&sku=63&qty=1&seller=1&sku=342&qty=1&seller=1&sku=39&qty=1&seller=1).

You should see that the summary sticks to the top when you scroll down the page, although it doesn't work quite well when you have a short screen height (you would need to scroll all the way down to see the "Continue" button).

#### Screenshots or example usage:

![sticky_summary](https://user-images.githubusercontent.com/10223856/95380940-d75d7700-08bd-11eb-84be-f9e5b32907f6.gif)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A
