### PR TITLE
Change checkout-cart title items quantity totalizer.

### DIFF
--- a/react/Title.tsx
+++ b/react/Title.tsx
@@ -42,7 +42,7 @@ const CartTitle: StorefrontFunctionComponent<Props> = ({ title }) => {
           >
             <FormattedMessage
               id="store/cart.items"
-              values={{ itemsQuantity: items.length }}
+              values={{ itemsQuantity: items.reduce((total, next) => total + next.quantity, 0) }}
             />
           </span>
         )}


### PR DESCRIPTION
#### What problem is this solving?

As described [here](https://vtex-dev.atlassian.net/secure/RapidBoard.jspa?rapidView=217&projectKey=CHK&modal=detail&selectedIssue=CHK-338), checkout-cart was showing items total quantity considering the number of different items, not the total items quantity in fact.

#### How to test it?

[Workspace](https://chk338--checkoutio.myvtex.com/cart)
Add diferent items to cart and modify the quantity of these items. The total displayed in checkout-cart title should reflect the quantity changes.

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/11471014/98154860-2d6d0c80-1eb4-11eb-8a57-54c3edbf4796.png)